### PR TITLE
#18 add http /health path to xterm server

### DIFF
--- a/run/health/check.js
+++ b/run/health/check.js
@@ -1,0 +1,22 @@
+var http = require("http");
+const https = require('https');
+// utils
+const inMemoryConfig            = require("../runtime.datastore");
+const inMemoryConfigFromInputs  = require('../runtime.datastore.config');
+
+if(inMemoryConfigFromInputs && inMemoryConfigFromInputs.web && inMemoryConfigFromInputs.web.url) {
+    let hcUrl = inMemoryConfigFromInputs.web.url + '/health';    
+    var request = http.get(hcUrl, (res) => {
+        if (res.statusCode == 200) {
+            process.exit(0);
+        } else {
+            process.exit(1);
+        }
+    });
+    request.on("error", function (err) {
+        process.exit(1);
+    });
+    request.end();
+} else {
+    process.exit(1);
+}

--- a/run/health/index.js
+++ b/run/health/index.js
@@ -1,0 +1,60 @@
+const http = require('http');
+let EventEmitter = require('events').EventEmitter;
+const { replacePortNumber } = require("../utils");
+
+class HealthCheckerUtility extends EventEmitter {
+    inMemoryConfig;
+    isXtermSocketAlive  = false;
+    isWebServerAlive    = false;
+    canG2ToolsExec      = false;
+    pingTime = 30000;
+
+    constructor(inMemoryConfigObj) {
+        super();
+
+        if(inMemoryConfigObj) {
+            this.inMemoryConfig = inMemoryConfigObj;
+        }
+        // set up interval timers to check status
+        this.isXTermServerAliveTimer    = setInterval(this.checkIfXtermAlive.bind(this), this.pingTime);
+        this.isWebServerAliveTimer      = setInterval(this.checkIfWebServerAlive.bind(this), this.pingTime);
+        this.canG2ToolsExecTimer        = setInterval(this.checkIfG2ToolsExec.bind(this), this.pingTime);
+        // immediately perform checks
+        this.checkIfXtermAlive();
+        this.checkIfWebServerAlive();
+        this.checkIfG2ToolsExec();
+    }
+    get status() {
+        return {
+            "isXtermSocketAlive": this.isXtermSocketAlive,
+            "isWebServerAlive": this.isWebServerAlive,
+            "canG2ToolsExec": this.canG2ToolsExec
+        }
+    }
+    get config() {
+        return this.inMemoryConfig.config;
+    }
+    checkIfXtermAlive() {
+        /** 
+         * @TODO fill out logic here that actually opens up a web socket
+         * and checks for a response.
+         */
+        this.isXtermSocketAlive = true;
+    }
+    checkIfWebServerAlive() {
+        /** 
+         * @TODO fill out logic here that actually opens up a http request
+         * and checks for a response.
+         */
+        this.isWebServerAlive = false;
+    }
+    checkIfG2ToolsExec() {
+        /** 
+         * @TODO fill out logic here that actually opens up a PTY and 
+         * executes a G2Command to smoke test
+         */
+        this.canG2ToolsExec = true;
+    }
+}
+
+module.exports = HealthCheckerUtility;

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -1,0 +1,5 @@
+// utils
+const inMemoryConfig = require("../runtime.datastore");
+const inMemoryConfigFromInputs = require('../runtime.datastore.config');
+const runtimeOptions = new inMemoryConfig(inMemoryConfigFromInputs);
+


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

part of #18 
(most of this code was borrowed from the `/health` logic used in the [entity-search-web-app project](https://github.com/Senzing/entity-search-web-app/tree/main/run/health). I just stubbed out the inner methods for now, lemme know if you want to change anything or something would make your life easier  ;-)

## Why was change needed

we needed a way to check operation state of container for ecs/cloud monitoring.

## What does change improve

This adds a `/health` path to the server on the port defined. the response returned is JSON in the following format:
```JSON
{"isXtermSocketAlive":true,"isWebServerAlive":false,"canG2ToolsExec":true}
```
