### PR TITLE
removed global npm install from runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,6 @@ RUN wget -q -O - https://deb.nodesource.com/setup_16.x | bash -
 
 RUN apt-get -yq install \
     nodejs \
- && npm install -g npm \
  && node -v
 
 # Install packages via pip.


### PR DESCRIPTION
removed global npm install from runtime container. since the command wasn't version pinned it was installing the latest version which was incompatible with the version in the base img.
